### PR TITLE
Add Terraform example for AWS deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.tfstate*
+.terraform/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@
 - `app.py` : Flask アプリ本体
 - `templates/index.html` : アップロードフォーム
 - `requirements.txt` : 必要な Python パッケージ
+
+## Terraform でのデプロイ例
+AWS 上に EC2 インスタンスを作成してアプリを公開するシンプルなサンプルを `terraform`
+ディレクトリに用意しています。以下のように実行します。
+
+```bash
+cd terraform
+terraform init
+terraform apply
+```
+
+`ami_id` や `key_name` などの変数は `-var` オプションや `terraform.tfvars`
+ファイルで指定してください。適用後、出力される `instance_public_ip` にブラウザ
+からアクセスすることでアプリを確認できます。

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_version = ">= 1.1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_security_group" "app" {
+  name        = "mosic-app-sg"
+  description = "Allow HTTP traffic"
+
+  ingress {
+    from_port   = var.port
+    to_port     = var.port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  key_name      = var.key_name
+  vpc_security_group_ids = [aws_security_group.app.id]
+
+  user_data = <<-EOF2
+              #!/bin/bash
+              apt-get update
+              apt-get install -y python3 python3-pip git
+              git clone https://github.com/YOUR_GITHUB_USERNAME/mosic_ai_codex /opt/mosic_ai_codex
+              pip3 install -r /opt/mosic_ai_codex/requirements.txt
+              PORT=${var.port} nohup python3 /opt/mosic_ai_codex/app.py &
+              EOF2
+
+  tags = {
+    Name = "mosic-ai-codex"
+  }
+}
+
+output "instance_public_ip" {
+  value = aws_instance.app.public_ip
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.app.public_ip
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "ami_id" {
+  description = "AMI ID for the instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "key_name" {
+  description = "Name of the SSH key pair"
+  type        = string
+}
+
+variable "port" {
+  description = "Port number the app will use"
+  type        = number
+  default     = 8000
+}


### PR DESCRIPTION
## Summary
- provide sample Terraform configuration to deploy the Flask app on AWS
- update README with instructions for using Terraform
- add `.gitignore` for cache and Terraform state

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684d8c8cde0483228babf4a7228b8b95