### PR TITLE
Allow SSH in Terraform and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ terraform apply
    terraform apply
    ```
 6. 数分待つと EC2 インスタンスが起動し、`instance_public_ip` が表示されます。ブラウザで `http://<表示されたIP>:<port>` を開くとアプリにアクセスできます。
+7. 必要に応じて次のコマンドで SSH 接続も行えます。
+   ```bash
+   ssh -i <作成したpemファイル> ubuntu@<instance_public_ip>
+   ```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,14 @@ resource "aws_security_group" "app" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Allow SSH access
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
## Summary
- open port 22 in the Terraform security group
- mention SSH connection in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684da05a64648322990af1ae99e96429